### PR TITLE
Add node_modules to import resolver

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        moduleDirectory: ['./src'],
+        moduleDirectory: ['./node_modules', './src'],
       },
     },
   },


### PR DESCRIPTION
I just realized that I was wrong. It looks like we do need to add `node_modules` there